### PR TITLE
locateSSID defect fix

### DIFF
--- a/iSniff_GPS/templates/wigle-wloc.html
+++ b/iSniff_GPS/templates/wigle-wloc.html
@@ -38,7 +38,7 @@ $.ajax({
 {% block content %}
 <h2>SSID</h2>
 <input id="SSID" value="{{ ssid }}">
-<input type="submit" value="Go" onclick='window.location="{% url "locatessid-base" %}"+document.getElementById("SSID").value'>
+<input type="submit" value="Go" onclick='window.location="{% url "locatessid-base" %}/"+document.getElementById("SSID").value'>
 {% if hits %}{{hits}} APs returned.{%endif%}
 <div id="map_canvas"></div>
 {% endblock %}


### PR DESCRIPTION
Fix defect 'SSID Search' page so that pressing 'Go' loads locateSSID/ap_name instead of locateSSIDap_name
