### PR TITLE
Fixed "Models aren't loaded yet" Django error

### DIFF
--- a/iSniff_import.py
+++ b/iSniff_import.py
@@ -10,6 +10,7 @@ from datetime import datetime #for utcfromtimestamp
 from iSniff_GPS.models import Client, AP, Location
 from collections import defaultdict
 
+import django
 import code
 import binascii
 import argparse
@@ -17,6 +18,7 @@ import json
 import sys
 import re
 
+django.setup()
 parser = argparse.ArgumentParser(description='iSniff GPS Server')
 parser.add_argument('-r', dest='pcap', action='store', help='pcap file to read')
 parser.add_argument('-i', dest='interface', action='store', default='mon0', help='interface to sniff (default mon0)')


### PR DESCRIPTION
This error happened to me I don't know why (maybe it only happens in newer Django versions) when using the command "./run.sh -i mon0" (mon0 is a monitor mode interface) in Kali Linux 64bit 1.0.9a. I was using Python 2.7.3 and Django 1.7.3. I just fixed it setuping Django coding the line "django.setup" at the beginning of the application.