### PR TITLE
Fix wigle search

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ iSniff GPS contains 2 major components and further python modules:
 
 * __wloc.py__ provides a _QueryBSSID()_ function which looks up a given BSSID (AP MAC address) on Apple's WiFi location service. It will return the coordinates of the MAC queried for and usually an additional 400 nearby BSSIDs and their coordinates.
 
-* __wigle.py__ provides a _getLocation()_ function for querying a given SSID on the wigle.net database and returns GPS coordinates. It must be configured with a valid wigle.net auth cookie. Please respect the wigle.net ToS in using this module.
+* __wigle.py__ provides a _getLocation()_ function for querying a given SSID on the wigle.net database and returns GPS coordinates. It must be configured with a valid username and password set in the settings.py file. Please respect the wigle.net ToS in using this module.
 
 Instructions
 ------------

--- a/iSniff_GPS/settings.py
+++ b/iSniff_GPS/settings.py
@@ -1,3 +1,9 @@
+#Wigle settings
+
+wigle_username = 'Bugmenot'
+wigle_password = 'hello'
+
+
 # Django settings for iSniff_GPS project.
 
 DEBUG = True

--- a/iSniff_GPS/views.py
+++ b/iSniff_GPS/views.py
@@ -6,7 +6,7 @@ from django.db.models import Count
 from datetime import datetime
 from models import *
 from string import lower
-import wigle
+import wigle_api
 import wloc
 import re
 from netaddr import EUI
@@ -190,7 +190,7 @@ def AppleMobile(request,cellid=None,LTE=False):
 
 def locateSSID(request,ssid=None):
 	if ssid:
-		apdict = wigle.getLocation(SSID=ssid)
+		apdict = wigle_api.getLocation(SSID=ssid)
 		numresults = len(apdict)
 		if numresults == 0:
 			return HttpResponse('0 results.')

--- a/iSniff_GPS/wigle_api.py
+++ b/iSniff_GPS/wigle_api.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+import settings
+from wigle import Wigle
+# parse lat/lon from hrefs in results page like
+# <a href="/gps/gps/Map/onlinemap2/?maplat=39.89233017&maplon=-86.15497589&mapzoom=17&ssid=NETGEAR&netid=00:00:85:E7:0C:01">Get Map</a>
+print settings.ROOT_URLCONF
+def getLocation(BSSID='',SSID=''):
+	wigle = Wigle(settings.wigle_username, settings.wigle_password)
+	results = wigle.search(ssid=SSID) 
+	apdict={}
+	count=1
+	for result in results:
+		lat = float(result['trilat'])     
+		lon = float(result['trilong'])  
+		ssid_result = result['ssid'] #match any number of non-& characters
+		bssid_result = result['netid']
+		if SSID and ssid_result==SSID: # exact case sensitive match
+			id = '%s [%s] [%s]' % (SSID,bssid_result,count)
+			apdict[id]=(lat,lon)
+			count+=1
+	return apdict

--- a/iSniff_GPS/wigle_api.py
+++ b/iSniff_GPS/wigle_api.py
@@ -3,7 +3,6 @@ import settings
 from wigle import Wigle
 # parse lat/lon from hrefs in results page like
 # <a href="/gps/gps/Map/onlinemap2/?maplat=39.89233017&maplon=-86.15497589&mapzoom=17&ssid=NETGEAR&netid=00:00:85:E7:0C:01">Get Map</a>
-print settings.ROOT_URLCONF
 def getLocation(BSSID='',SSID=''):
 	wigle = Wigle(settings.wigle_username, settings.wigle_password)
 	results = wigle.search(ssid=SSID) 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ django-picklefield
 dnslib
 netaddr
 requests
-BeautifulSoup4
 protobuf==2.6.1
 #above requirements are for web interface only - also need scapy for sniffing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 django==1.7.1
 django-picklefield
 dnslib
+wigle
 netaddr
 requests
 protobuf==2.6.1


### PR DESCRIPTION
When trying to use iSniff the wigle search was not working, so I used the wigle python module that allows the use of username and password.  

I have put the settings for the username and password in settings.py 

The requirements and readme have also been updated to reflect the changes.